### PR TITLE
Bump mina core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
     <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
     <maven.version>3.9.9</maven.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
-    <mina.core.version>2.2.3</mina.core.version>
+    <mina.core.version>2.2.4</mina.core.version>
     <!-- if changing this version please update default in MongoTestHelper you will get thanks from Eclipse IDE users -->
     <mongo.docker.version>3.2.20</mongo.docker.version>
     <mongodb.version>3.12.14</mongodb.version>


### PR DESCRIPTION
**Purpose**: Bump mina core version to address Security vulberaibilty in v11.0.x
[CVE-2024-52046](https://nvd.nist.gov/vuln/detail/CVE-2024-52046)

org.apache.mina_mina-core
Version: 2.2.3
Status: fixed in 2.2.4, 2.1.10, 2.0.27
_The ObjectSerializationDecoder in Apache MINA uses Java’s native deserialization protocol to process incoming serialized data but lacks the necessary security checks and defenses. This vulnerability allows attackers to exploit the deserialization process by sending specially crafted malicious serialized data, potentially leading to remote code execution (RCE) attacks. This issue affects MINA core versions 2.0.X, 2.1.X and 2.2.X, and will be fixed by the releases 2.0.27, 2.1.10 and 2.2.4._

**Note**:
Jetty 12.0.x has mina core version v.2.2.4. However, our application (and there could be many others) who aren't quite ready to upgrade to v12.0.x yet while at the same time having to deal with CVE-2024-52046, which has a CVSS 10 - Critical.